### PR TITLE
Unify OpenAI env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Example environment configuration for the Jeffrey bot
+
+# Discord credentials
+ACCESS_TOKEN_DISCORD=your-discord-token
+CLIENT_ID=your-discord-client-id
+GUILD_ID=your-guild-id
+
+# PostgreSQL connection string
+DATABASE_URL=postgres://username:password@host:5432/database
+
+# OpenAI API key
+OPENAI_API_KEY=your-openai-api-key

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # Jeffrey
-# Jeffrey
+
+A Discord bot powered by OpenAI. To run the bot locally, copy `.env.example` to `.env` and fill in the required values.
+
+## Required environment variables
+
+- `ACCESS_TOKEN_DISCORD` – Discord bot token
+- `CLIENT_ID` – Discord application client ID
+- `GUILD_ID` – ID of the guild where commands are deployed
+- `DATABASE_URL` – PostgreSQL connection string
+- `OPENAI_API_KEY` – OpenAI API key used for all features
+
+After configuring `.env`, install dependencies with `npm install` and start the bot using `npm start`.

--- a/features/openaiService.js
+++ b/features/openaiService.js
@@ -1,8 +1,8 @@
 // features/openaiService.js
 const OpenAI = require("openai");
-const { ACCESS_TOKEN_OPENAI } = process.env;
+const { OPENAI_API_KEY } = process.env;
 
-const openai = new OpenAI({ apiKey: ACCESS_TOKEN_OPENAI });
+const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
 
 let log = [{ role: "system", content: "You are a general friendly assistant who is knowledgeable about code." }];
 


### PR DESCRIPTION
## Summary
- use `OPENAI_API_KEY` across features
- add an example `.env` file
- document environment variables in README

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687ca03257a88320aa5ecd42ab9c53ad