### PR TITLE
Add database schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # Jeffrey
-# Jeffrey
+
+Jeffrey is a Discord bot that manages student queues and logs public message history.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Create a PostgreSQL database and load the schema:
+   ```bash
+   psql < schema.sql
+   ```
+3. Create a `.env` file with at least:
+   ```
+   DATABASE_URL=postgres://USER:PASS@HOST:PORT/DBNAME
+   ACCESS_TOKEN_DISCORD=your-bot-token
+   CLIENT_ID=your-app-id
+   ```
+4. Start the bot:
+   ```bash
+   npm start
+   ```
+
+The `schema.sql` file defines the following tables used by the bot:
+- `queues` – stores queue names and member user IDs
+- `blacklisted_users` – records users blocked from specific queues
+- `public_messages` – archives messages for history lookups

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,34 @@
+-- PostgreSQL schema for Jeffrey bot
+
+-- Table of queues students can join
+CREATE TABLE IF NOT EXISTS queues (
+    id          SERIAL PRIMARY KEY,
+    server_id   BIGINT NOT NULL,
+    queue_name  TEXT   NOT NULL,
+    members     BIGINT[] NOT NULL DEFAULT '{}',
+    description TEXT,
+    UNIQUE (server_id, queue_name)
+);
+
+-- Table recording which users are blacklisted from specific queues
+CREATE TABLE IF NOT EXISTS blacklisted_users (
+    server_id BIGINT NOT NULL,
+    queue_id  INTEGER NOT NULL REFERENCES queues(id) ON DELETE CASCADE,
+    user_id   BIGINT NOT NULL,
+    PRIMARY KEY (server_id, queue_id, user_id)
+);
+
+-- Logged public messages for dmHistory lookups
+CREATE TABLE IF NOT EXISTS public_messages (
+    id         BIGINT PRIMARY KEY,
+    guild_id   BIGINT NOT NULL,
+    channel_id BIGINT NOT NULL,
+    author_id  BIGINT NOT NULL,
+    author_tag TEXT  NOT NULL,
+    content    TEXT  NOT NULL,
+    ts         TIMESTAMPTZ NOT NULL,
+    tsv        TSVECTOR GENERATED ALWAYS AS (to_tsvector('english', content)) STORED
+);
+
+CREATE INDEX IF NOT EXISTS idx_public_messages_guild ON public_messages(guild_id);
+CREATE INDEX IF NOT EXISTS idx_public_messages_tsv ON public_messages USING GIN(tsv);


### PR DESCRIPTION
## Summary
- add `schema.sql` defining tables used by the bot
- document database setup and env vars in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687ca0392b3483208431aba2da998c2a