### PR TITLE
Add privacy notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # Jeffrey
-# Jeffrey
+
+Jeffrey is a Discord bot that logs public messages to a PostgreSQL database. These stored messages may be sent to OpenAI's API to provide smart responses and history search features.
+
+## Privacy
+
+Messages from public channels are saved indefinitely in PostgreSQL for search and analysis. They may also be shared with OpenAI when generating responses. Delete requests are honored when a message is removed from Discord.
+
+When deploying Jeffrey, notify your server members that their messages are being logged and may be processed through OpenAI's services.
+


### PR DESCRIPTION
## Summary
- add note in README that public messages are stored in PostgreSQL
- mention that data may be sent to OpenAI and retention policy
- advise notifying server members about message logging

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687ca03a881c8320b86c06e41f942d9e